### PR TITLE
refactor: getNearestNodeInDirection to transducer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -915,6 +915,12 @@
       "integrity": "sha512-78AdXtlhpCHT0K3EytMpn4JNxaf5tbqbLcbIRoQIHzpTIyjpxLQKRoxU55ujBXAtg3Nl2h/XWvfDa9dsMOd0pQ==",
       "dev": true
     },
+    "@types/transducers.js": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@types/transducers.js/-/transducers.js-0.3.0.tgz",
+      "integrity": "sha512-ZAHByx9pi7o0fLvGMGJbvtETHXINIAb37sqy2Pl4UgbAwwyJPrypKEqroPSUccHQW2uby862vYOBSzJnJI5YoA==",
+      "dev": true
+    },
     "@types/uglify-js": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
@@ -9188,6 +9194,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "transducers.js": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/transducers.js/-/transducers.js-0.3.2.tgz",
+      "integrity": "sha1-eJAu91XgYGzS/dFjORLxCTyKVDI="
     },
     "trim-right": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,14 +17,15 @@
   },
   "homepage": "https://github.com/ksandin/sekiro#readme",
   "dependencies": {
+    "@material-ui/core": "3.9.2",
+    "classnames": "2.2.6",
     "mobx": "5.9.0",
     "mobx-react-lite": "1.2.0",
     "react": "16.8.5",
     "react-dom": "16.8.5",
     "react-hot-loader": "4.8.0",
-    "@material-ui/core": "3.9.2",
-    "classnames": "2.2.6",
-    "responsive-gamepad": "1.2.0"
+    "responsive-gamepad": "1.2.0",
+    "transducers.js": "^0.3.2"
   },
   "devDependencies": {
     "@babel/core": "7.4.0",
@@ -36,6 +37,7 @@
     "@types/react-dom": "16.8.3",
     "@types/react-hot-loader": "4.1.0",
     "@types/react-test-renderer": "16.8.1",
+    "@types/transducers.js": "^0.3.0",
     "awesome-typescript-loader": "5.2.1",
     "file-loader": "3.0.1",
     "html-webpack-plugin": "3.2.0",


### PR DESCRIPTION
Here is another version that uses a [transducer](https://github.com/jlongster/transducers.js#transducersjs) to optimize the multiple transformations, see the [benchmarks](https://jlongster.com/Transducers.js-Round-2-with-Benchmarks). The general idea is that each item passes through the entire composed transformation before moving onto the next item, so it essentially composes multiple loops into a single loop. That being said, this will be slower than #19 due to the transducer overhead, and it adds an extra dependency. I mostly just wanted to play with transducers and it was fun 👍 